### PR TITLE
Fixed responsiveness for Team Boxes issue(#9)

### DIFF
--- a/src/components/Team.astro
+++ b/src/components/Team.astro
@@ -14,10 +14,10 @@ import Collapse from "./Collapse.astro"
   </div>
 
   <div class="flex-row items-center py-5" id="team">
-    <div class="grid grid-cols-1 sm:grid-cols-1 md:grid-cols-3 gap-4">
+    <div class="grid grid-cols-1 sm:grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
       {
         teamData.team.map(({ title, description, name, link, profile }) => (
-          <div class="h-[331px] px-[35px] py-10 bg-white rounded-[45px] shadow-card border border-zinc-900 flex-col justify-start items-start gap-2.5 inline-flex text-black">
+          <div class="h-[330px] px-[35px] py-10  bg-white rounded-[45px] shadow-card border border-zinc-900 flex-col justify-start items-start gap-2.5 inline-flex text-black">
             <div class="flex-col justify-start items-start gap-7 flex">
               <div class="self-stretch justify-start items-start inline-flex">
                 <div class="grow shrink basis-0 justify-start items-center gap-8 flex">
@@ -34,7 +34,7 @@ import Collapse from "./Collapse.astro"
                 </a>
               </div>
               <hr class="w-full border border-black" />
-              <p class="text-sm md:text-lg">{description}</p>
+              <p class="text-sm md:text-base xl:text-lg">{description}</p>
             </div>
           </div>
         ))


### PR DESCRIPTION
## Describe your changes
- changed number of div displayed from 3 to 2 on smaller viewport so that content don't overflow
- made text size of the description on Team Boxes responsive

## Context
This PR introduces a fix to responsiveness of the Team Boxes mentioned in issue (https://github.com/b0sc/b0sc.github.io/issues/9).

## Checklist before requesting a review

- [ ] If it is a core feature, I have added thorough tests
- [ ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have only one commit (if not, squash them into one commit)
- [x ] This PR is not a duplicate

 <!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->