### PR TITLE
Fix: Change FAQ CSS to contain two columns in a row. #14

### DIFF
--- a/src/components/Collapse.astro
+++ b/src/components/Collapse.astro
@@ -4,25 +4,28 @@ const { label, index = null } = Astro.props
 
 <div class="group outline-none accordion-section" tabindex="1">
   <div
-    class="group group-focus:bg-lime group-focus:shadow-none shadow-card bg-zinc-100 group-focus:rounded-b-none group-focus:rounded-t-3xl rounded-3xl flex justify-between px-4 py-3 items-center transition-colors ease duration-500 cursor-pointer pr-10 relative"
+    class="group h-[170px] group-focus:bg-lime group-focus:shadow-none shadow-card bg-zinc-100 group-focus:rounded-b-none group-focus:rounded-t-3xl rounded-3xl flex justify-between px-4 py-3 items-center transition-colors ease duration-500 cursor-pointer pr-10 relative"
   >
     <div
       class="flex items-center group-focus:text-black px-10 pt-10 w-full transition ease duration-500"
     >
       <div class="flex pb-10 gap-5 w-full items-center">
-        <div class="flex justify-between w-full items-center rouded-full">
+        <div class="flex justify-between w-full items-center rounded-full">
           <div class="flex items-center gap-5">
             {
               index && (
                 <>
-                  <p class="text-6xl font-medium flex items-center">{index}</p>
-                  <p class="lg:text-3xl text-lg">{label}</p>
+                  <p class="text-5xl font-medium flex items-center">{index}</p>
+                  <!-- Initially clamp to 2 lines, expand when clicked -->
+                  <p class="text-2xl px-4 overflow-hidden text-ellipsis line-clamp-2 group-focus:line-clamp-none transition-all duration-500">
+                    {label}
+                  </p>
                 </>
               )
             }
           </div>
           <div
-            class="rounded-full after:h-[2px] relative accodion-chevron border-black md:border-2 flex md:items-center md:bg-zinc-100 h-12 w-12"
+            class="rounded-full after:h-[2px] relative accodion-chevron border-black md:border-2 flex md:items-center md:bg-zinc-100 h-10 w-10 px-4"
           >
           </div>
         </div>
@@ -38,16 +41,33 @@ const { label, index = null } = Astro.props
   </div>
 </div>
 
+<!-- Add styles for line-clamp -->
 <style>
+  /* Chevron style for the plus sign (+) */
   .accodion-chevron::after {
     content: "";
-    @apply h-[70%] w-[8px] transform transition-transform bg-black absolute left-1/2 -translate-x-1/2;
+    @apply h-[53%] w-[8px] transform transition-transform duration-500 bg-black absolute left-1/2 -translate-x-1/2;
   }
   .accodion-chevron::before {
     content: "";
-    @apply h-[70%] w-[8px] rotate-90 transform bg-black absolute left-1/2 -translate-x-1/2;
+    @apply h-[53%] w-[8px] rotate-90 transform transition-transform duration-500 bg-black absolute left-1/2 -translate-x-1/2;
   }
+
+  /* Change to minus sign (-) when focused (expanded) */
   .group:focus-within .accodion-chevron::after {
     @apply rotate-90;
+  }
+
+  /* Clamping text to 2 lines initially */
+  .line-clamp-2 {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
+  }
+
+  /* Expand to full content on focus */
+  .group:focus-within .line-clamp-none {
+    -webkit-line-clamp: unset;
   }
 </style>

--- a/src/components/Team.astro
+++ b/src/components/Team.astro
@@ -54,16 +54,16 @@ import Collapse from "./Collapse.astro"
   <div class="relative flex flex-col items-center md:flex-row">
     <Topic title="FAQs" description="Questions repeatedly asked to BOSC." />
   </div>
-  <!-- edit team.json file in faqs with the help of content creator -->
-  <div class="my-6">
-    <div class="space-y-10">
-      {
-        teamData.faqs.map((faq, key) => (
-          <Collapse label={faq.question} index={key + 1}>
-            {faq.answer}
-          </Collapse>
-        ))
-      }
-    </div>
+  
+  <!-- Adjust the grid layout and size of FAQ boxes -->
+  <div class="my-6 grid grid-cols-1 md:grid-cols-2 gap-4">
+    {teamData.faqs.map((faq, key) => (
+      <Collapse 
+        key={key} 
+        label={faq.question} 
+        index={key + 1}>
+        {faq.answer}
+      </Collapse>
+    ))}
   </div>
 </Container>


### PR DESCRIPTION
## Describe your changes:

- Updated FAQ CSS to display two columns on larger screens, reducing size, text-size, and height for better space usage. Maintained one FAQ per row on mobile with reduced height.
- Resolved FAQ accordion inconsistency by limiting text to 2 lines initially using Tailwind CSS's line-clamp-2, expanding the full content when focused.


## Context:

- Optimized FAQ layout to reduce vertical space, maintaining a clean, responsive UI with two columns on larger screens and one on mobile devices.
- Fixed uneven FAQ section heights caused by varying text lengths, ensuring uniform height when collapsed and expanded content on interaction. #14


## Checklist before requesting a review

- [ ]  If it is a core feature, I have added thorough tests
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ]   I have made corresponding changes to the documentation
- [X] I have only one commit (if not, squash them into one commit)
- [X] This PR is not a duplicate

Closes #14 (if applicable)